### PR TITLE
Initiate signing on checkbox click

### DIFF
--- a/src/modules/ui/components/TermsModal.tsx
+++ b/src/modules/ui/components/TermsModal.tsx
@@ -92,6 +92,10 @@ export function TermsModal() {
 
   const handleCheckboxChange = (checkedState: CheckedState) => {
     setIsChecked(checkedState === true);
+    if (checkedState === true) {
+      setSignStatus('signing');
+      signMessage({ message: import.meta.env.VITE_TERMS_MESSAGE_TO_SIGN });
+    }
   };
 
   return (


### PR DESCRIPTION
The signature pop-up will require one less click by initiating the signature once the checkbox is checked. If the user closes the pop-up without signing, then they can still click "Agree and sign" to re-initiate it.