### PR TITLE
Network switching functionality for P1D

### DIFF
--- a/src/components/DualSwitcher.tsx
+++ b/src/components/DualSwitcher.tsx
@@ -1,9 +1,11 @@
 import { HStack } from '@/modules/layout/components/HStack';
 import { DetailsSwitcher } from './DetailsSwitcher';
+import { NetworkSwitcer } from './NetworkSwitcher';
 
 export function DualSwitcher(): JSX.Element {
   return (
-    <HStack className="space-x-0">
+    <HStack className="items-center gap-4 space-x-0">
+      <NetworkSwitcer />
       <DetailsSwitcher />
     </HStack>
   );

--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -1,0 +1,45 @@
+import { tenderlyBase } from '@/data/wagmi/config/config.default';
+import { MainnetNetwork, BaseNetwork } from '@/modules/icons';
+import { useChainModal } from '@rainbow-me/rainbowkit';
+import { base } from 'viem/chains';
+import { useChainId } from 'wagmi';
+import { Tooltip, TooltipArrow, TooltipContent, TooltipPortal, TooltipTrigger } from './ui/tooltip';
+import { Text } from '@/modules/layout/components/Typography';
+import { Trans } from '@lingui/macro';
+import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
+import { Intent } from '@/lib/enums';
+
+export function NetworkSwitcer() {
+  const chainId = useChainId();
+  const { openChainModal } = useChainModal();
+  const { userConfig } = useConfigContext();
+
+  const { intent } = userConfig;
+  const supportedMultichainWidgets = [
+    Intent.BALANCES_INTENT,
+    // TODO: Uncomment once rewards in Base support is added
+    // Intent.REWARDS_INTENT,
+    Intent.SAVINGS_INTENT,
+    Intent.TRADE_INTENT
+  ];
+
+  if (!supportedMultichainWidgets.includes(intent)) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="cursor-pointer" onClick={openChainModal}>
+          {chainId === base.id || chainId === tenderlyBase.id ? <BaseNetwork /> : <MainnetNetwork />}
+        </div>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent arrowPadding={10}>
+          <Text variant="small">
+            <Trans>Switch network</Trans>
+          </Text>
+          <TooltipArrow width={12} height={8} />
+        </TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,8 @@ import { RewardsModule, Savings, Trade, Upgrade, Seal } from '@/modules/icons';
 import { Intent } from './enums';
 import { msg } from '@lingui/macro';
 import { MessageDescriptor } from '@lingui/core';
+import { base, mainnet, sepolia } from 'viem/chains';
+import { tenderly, tenderlyBase } from '@/data/wagmi/config/config.default';
 
 export enum QueryParams {
   Locale = 'lang',
@@ -25,6 +27,32 @@ export const IntentMapping = {
   [Intent.SAVINGS_INTENT]: 'savings',
   [Intent.REWARDS_INTENT]: 'rewards',
   [Intent.SEAL_INTENT]: 'seal'
+};
+
+export const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
+  [mainnet.id]: [
+    Intent.BALANCES_INTENT,
+    Intent.REWARDS_INTENT,
+    Intent.SAVINGS_INTENT,
+    Intent.UPGRADE_INTENT,
+    Intent.TRADE_INTENT,
+    Intent.SEAL_INTENT
+  ],
+  [tenderly.id]: [
+    Intent.BALANCES_INTENT,
+    Intent.REWARDS_INTENT,
+    Intent.SAVINGS_INTENT,
+    Intent.UPGRADE_INTENT,
+    Intent.SEAL_INTENT
+  ],
+  [base.id]: [Intent.BALANCES_INTENT, Intent.REWARDS_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT],
+  [tenderlyBase.id]: [
+    Intent.BALANCES_INTENT,
+    Intent.REWARDS_INTENT,
+    Intent.SAVINGS_INTENT,
+    Intent.TRADE_INTENT
+  ],
+  [sepolia.id]: [Intent.BALANCES_INTENT, Intent.TRADE_INTENT]
 };
 
 export const intentTxt: Record<string, MessageDescriptor> = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -55,6 +55,11 @@ export const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
   [sepolia.id]: [Intent.BALANCES_INTENT, Intent.TRADE_INTENT]
 };
 
+export const COMING_SOON_MAP: Record<number, Intent[]> = {
+  [base.id]: [Intent.REWARDS_INTENT],
+  [tenderlyBase.id]: [Intent.REWARDS_INTENT]
+};
+
 export const intentTxt: Record<string, MessageDescriptor> = {
   trade: msg`trade`,
   upgrade: msg`upgrade`,

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -480,6 +480,10 @@ msgstr ""
 msgid "sUSDS is a savings token for eligible users. When you supply USDS to the Sky Savings Rate module, you access the Sky Savings Rate and may receive sUSDS tokens. These sUSDS tokens serve as a digital record of your USDS interaction with the SSR module and any value accrued to your position."
 msgstr ""
 
+#: src/components/NetworkSwitcher.tsx
+msgid "Switch network"
+msgstr ""
+
 #: src/modules/app/hooks/useNotification.tsx
 msgid "then get rewards"
 msgstr ""

--- a/src/locales/es-AR.po
+++ b/src/locales/es-AR.po
@@ -480,6 +480,10 @@ msgstr ""
 msgid "sUSDS is a savings token for eligible users. When you supply USDS to the Sky Savings Rate module, you access the Sky Savings Rate and may receive sUSDS tokens. These sUSDS tokens serve as a digital record of your USDS interaction with the SSR module and any value accrued to your position."
 msgstr ""
 
+#: src/components/NetworkSwitcher.tsx
+msgid "Switch network"
+msgstr ""
+
 #: src/modules/app/hooks/useNotification.tsx
 msgid "then get rewards"
 msgstr ""

--- a/src/locales/es-ES.po
+++ b/src/locales/es-ES.po
@@ -480,6 +480,10 @@ msgstr ""
 msgid "sUSDS is a savings token for eligible users. When you supply USDS to the Sky Savings Rate module, you access the Sky Savings Rate and may receive sUSDS tokens. These sUSDS tokens serve as a digital record of your USDS interaction with the SSR module and any value accrued to your position."
 msgstr ""
 
+#: src/components/NetworkSwitcher.tsx
+msgid "Switch network"
+msgstr ""
+
 #: src/modules/app/hooks/useNotification.tsx
 msgid "then get rewards"
 msgstr ""

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -480,6 +480,10 @@ msgstr ""
 msgid "sUSDS is a savings token for eligible users. When you supply USDS to the Sky Savings Rate module, you access the Sky Savings Rate and may receive sUSDS tokens. These sUSDS tokens serve as a digital record of your USDS interaction with the SSR module and any value accrued to your position."
 msgstr ""
 
+#: src/components/NetworkSwitcher.tsx
+msgid "Switch network"
+msgstr ""
+
 #: src/modules/app/hooks/useNotification.tsx
 msgid "then get rewards"
 msgstr ""

--- a/src/locales/ko.po
+++ b/src/locales/ko.po
@@ -482,6 +482,10 @@ msgstr ""
 msgid "sUSDS is a savings token for eligible users. When you supply USDS to the Sky Savings Rate module, you access the Sky Savings Rate and may receive sUSDS tokens. These sUSDS tokens serve as a digital record of your USDS interaction with the SSR module and any value accrued to your position."
 msgstr ""
 
+#: src/components/NetworkSwitcher.tsx
+msgid "Switch network"
+msgstr ""
+
 #: src/modules/app/hooks/useNotification.tsx
 msgid "then get rewards"
 msgstr ""

--- a/src/modules/app/components/MainApp.tsx
+++ b/src/modules/app/components/MainApp.tsx
@@ -77,7 +77,8 @@ export function MainApp() {
         CHAIN_WIDGET_MAP[chainId].find(
           intent =>
             intent === mapQueryParamToIntent(userConfig.intent) &&
-            !COMING_SOON_MAP[chainId].includes(mapQueryParamToIntent(userConfig.intent))
+            // If there is no coming soon map for the current network, default to true
+            (!COMING_SOON_MAP[chainId]?.includes(mapQueryParamToIntent(userConfig.intent)) ?? true)
         ) ??
         Intent.BALANCES_INTENT
     });

--- a/src/modules/app/components/MainApp.tsx
+++ b/src/modules/app/components/MainApp.tsx
@@ -3,7 +3,7 @@ import { WidgetPane } from './WidgetPane';
 import { DetailsPane } from './DetailsPane';
 import { AppContainer } from './AppContainer';
 import { useSearchParams } from 'react-router-dom';
-import { QueryParams, mapQueryParamToIntent } from '@/lib/constants';
+import { CHAIN_WIDGET_MAP, QueryParams, mapQueryParamToIntent } from '@/lib/constants';
 import { Intent } from '@/lib/enums';
 import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
 import { validateLinkedActionSearchParams, validateSearchParams } from '@/modules/utils/validateSearchParams';
@@ -50,7 +50,8 @@ export function MainApp() {
           params,
           rewardContracts,
           widgetParam || '',
-          setSelectedRewardContract
+          setSelectedRewardContract,
+          chainId
         );
         // Runs second validation for linked-action-specific criteria
         const validatedLinkedActionParams = validateLinkedActionSearchParams(validatedParams);
@@ -69,7 +70,11 @@ export function MainApp() {
 
     updateUserConfig({
       ...userConfig,
-      intent: validatedWidgetParam ?? userConfig.intent
+      // If user selected intent is not available for the current network, default to the balances intent
+      intent:
+        validatedWidgetParam ??
+        CHAIN_WIDGET_MAP[chainId].find(intent => intent === mapQueryParamToIntent(userConfig.intent)) ??
+        Intent.BALANCES_INTENT
     });
   }, [widgetParam, userConfig.intent]);
 

--- a/src/modules/app/components/MainApp.tsx
+++ b/src/modules/app/components/MainApp.tsx
@@ -3,7 +3,7 @@ import { WidgetPane } from './WidgetPane';
 import { DetailsPane } from './DetailsPane';
 import { AppContainer } from './AppContainer';
 import { useSearchParams } from 'react-router-dom';
-import { CHAIN_WIDGET_MAP, QueryParams, mapQueryParamToIntent } from '@/lib/constants';
+import { CHAIN_WIDGET_MAP, COMING_SOON_MAP, QueryParams, mapQueryParamToIntent } from '@/lib/constants';
 import { Intent } from '@/lib/enums';
 import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
 import { validateLinkedActionSearchParams, validateSearchParams } from '@/modules/utils/validateSearchParams';
@@ -73,7 +73,12 @@ export function MainApp() {
       // If user selected intent is not available for the current network, default to the balances intent
       intent:
         validatedWidgetParam ??
-        CHAIN_WIDGET_MAP[chainId].find(intent => intent === mapQueryParamToIntent(userConfig.intent)) ??
+        // Use the user config intent if found in the chain widget map, but not on the coming soon map for the given network
+        CHAIN_WIDGET_MAP[chainId].find(
+          intent =>
+            intent === mapQueryParamToIntent(userConfig.intent) &&
+            !COMING_SOON_MAP[chainId].includes(mapQueryParamToIntent(userConfig.intent))
+        ) ??
         Intent.BALANCES_INTENT
     });
   }, [widgetParam, userConfig.intent]);

--- a/src/modules/app/components/WidgetPane.tsx
+++ b/src/modules/app/components/WidgetPane.tsx
@@ -4,7 +4,7 @@ import { Intent } from '@/lib/enums';
 import { useLingui } from '@lingui/react';
 import { useCustomConnectModal } from '@/modules/ui/hooks/useCustomConnectModal';
 import { useAddRecentTransaction } from '@rainbow-me/rainbowkit';
-import { mapIntentToQueryParam, restrictedIntents } from '@/lib/constants';
+import { CHAIN_WIDGET_MAP, mapIntentToQueryParam, restrictedIntents } from '@/lib/constants';
 import { WidgetNavigation } from '@/modules/app/components/WidgetNavigation';
 import { withErrorBoundary } from '@/modules/utils/withErrorBoundary';
 import { DualSwitcher } from '@/components/DualSwitcher';
@@ -23,8 +23,8 @@ import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
 import { defaultConfig } from '@/modules/config/default-config';
 import { useChainId } from 'wagmi';
 import { SealWidgetPane } from '@/modules/seal/components/SealWidgetPane';
-import { base, mainnet, sepolia } from 'wagmi/chains';
-import { tenderly, tenderlyBase } from '@/data/wagmi/config/config.default';
+import { base } from 'wagmi/chains';
+import { tenderlyBase } from '@/data/wagmi/config/config.default';
 
 export type WidgetContent = [
   Intent,
@@ -38,32 +38,6 @@ export type WidgetContent = [
 type WidgetPaneProps = {
   intent: Intent;
   children?: React.ReactNode;
-};
-
-const CHAIN_WIDGET_MAP: Record<number, Intent[]> = {
-  [mainnet.id]: [
-    Intent.BALANCES_INTENT,
-    Intent.REWARDS_INTENT,
-    Intent.SAVINGS_INTENT,
-    Intent.UPGRADE_INTENT,
-    Intent.TRADE_INTENT,
-    Intent.SEAL_INTENT
-  ],
-  [tenderly.id]: [
-    Intent.BALANCES_INTENT,
-    Intent.REWARDS_INTENT,
-    Intent.SAVINGS_INTENT,
-    Intent.UPGRADE_INTENT,
-    Intent.SEAL_INTENT
-  ],
-  [base.id]: [Intent.BALANCES_INTENT, Intent.REWARDS_INTENT, Intent.SAVINGS_INTENT, Intent.TRADE_INTENT],
-  [tenderlyBase.id]: [
-    Intent.BALANCES_INTENT,
-    Intent.REWARDS_INTENT,
-    Intent.SAVINGS_INTENT,
-    Intent.TRADE_INTENT
-  ],
-  [sepolia.id]: [Intent.BALANCES_INTENT, Intent.TRADE_INTENT]
 };
 
 const COMING_SOON_MAP: Record<number, Intent[]> = {

--- a/src/modules/app/components/WidgetPane.tsx
+++ b/src/modules/app/components/WidgetPane.tsx
@@ -4,7 +4,7 @@ import { Intent } from '@/lib/enums';
 import { useLingui } from '@lingui/react';
 import { useCustomConnectModal } from '@/modules/ui/hooks/useCustomConnectModal';
 import { useAddRecentTransaction } from '@rainbow-me/rainbowkit';
-import { CHAIN_WIDGET_MAP, mapIntentToQueryParam, restrictedIntents } from '@/lib/constants';
+import { CHAIN_WIDGET_MAP, COMING_SOON_MAP, mapIntentToQueryParam, restrictedIntents } from '@/lib/constants';
 import { WidgetNavigation } from '@/modules/app/components/WidgetNavigation';
 import { withErrorBoundary } from '@/modules/utils/withErrorBoundary';
 import { DualSwitcher } from '@/components/DualSwitcher';
@@ -23,8 +23,6 @@ import { useConfigContext } from '@/modules/config/hooks/useConfigContext';
 import { defaultConfig } from '@/modules/config/default-config';
 import { useChainId } from 'wagmi';
 import { SealWidgetPane } from '@/modules/seal/components/SealWidgetPane';
-import { base } from 'wagmi/chains';
-import { tenderlyBase } from '@/data/wagmi/config/config.default';
 
 export type WidgetContent = [
   Intent,
@@ -38,11 +36,6 @@ export type WidgetContent = [
 type WidgetPaneProps = {
   intent: Intent;
   children?: React.ReactNode;
-};
-
-const COMING_SOON_MAP: Record<number, Intent[]> = {
-  [base.id]: [Intent.REWARDS_INTENT],
-  [tenderlyBase.id]: [Intent.REWARDS_INTENT]
 };
 
 export const WidgetPane = ({ intent, children }: WidgetPaneProps) => {

--- a/src/modules/icons/BaseNetwork.tsx
+++ b/src/modules/icons/BaseNetwork.tsx
@@ -1,0 +1,11 @@
+import { Icon, IconProps } from './Icon';
+
+export const BaseNetwork = (props: IconProps) => (
+  <Icon {...props} width="20" height="20" viewBox="0 0 20 20" fill="none">
+    <rect width="20" height="20" rx="3.3" fill="#0052FF" />
+    <path
+      d="M9.98944 16C13.3091 16 16 13.3139 16 10C16 6.68608 13.3091 4 9.98944 4C6.84016 4 4.2568 6.41824 4 9.49552H11.9445V10.5045H4C4.2568 13.5818 6.84016 16 9.98944 16Z"
+      fill="white"
+    />
+  </Icon>
+);

--- a/src/modules/icons/MainnetNetwork.tsx
+++ b/src/modules/icons/MainnetNetwork.tsx
@@ -1,0 +1,16 @@
+import { Icon, IconProps } from './Icon';
+
+export const MainnetNetwork = (props: IconProps) => (
+  <Icon {...props} width="20" height="20" viewBox="0 0 20 20" fill="none">
+    <rect width="20" height="20" rx="3.3" fill="#0052FF" />
+    <path d="M9.84818 2L9.74219 2.36462V12.9442L9.84818 13.0512L14.6972 10.1484L9.84818 2Z" fill="#BECDF9" />
+    <path d="M9.84914 2L5 10.1484L9.84914 13.0512V7.91623V2Z" fill="white" />
+    <path
+      d="M9.8488 13.9794L9.78906 14.0532V17.8218L9.8488 17.9984L14.7008 11.0781L9.8488 13.9794Z"
+      fill="#BECDF9"
+    />
+    <path d="M9.84914 17.9984V13.9794L5 11.0781L9.84914 17.9984Z" fill="white" />
+    <path d="M9.85156 13.0491L14.7006 10.1463L9.85156 7.91406V13.0491Z" fill="#7799F1" />
+    <path d="M5 10.1463L9.84914 13.0491V7.91406L5 10.1463Z" fill="#BECDF9" />
+  </Icon>
+);

--- a/src/modules/icons/index.ts
+++ b/src/modules/icons/index.ts
@@ -28,6 +28,8 @@ import { Info } from './Info';
 import { Close } from './Close';
 import { Seal } from './Seal';
 import { Toggle } from './Toggle';
+import { BaseNetwork } from './BaseNetwork';
+import { MainnetNetwork } from './MainnetNetwork';
 
 export {
   ArrowDown,
@@ -59,5 +61,7 @@ export {
   Info,
   Close,
   Seal,
-  Toggle
+  Toggle,
+  BaseNetwork,
+  MainnetNetwork
 };

--- a/src/modules/utils/validateSearchParams.ts
+++ b/src/modules/utils/validateSearchParams.ts
@@ -5,7 +5,8 @@ import {
   IntentMapping,
   VALID_LINKED_ACTIONS,
   CHAIN_WIDGET_MAP,
-  mapQueryParamToIntent
+  mapQueryParamToIntent,
+  COMING_SOON_MAP
 } from '@/lib/constants';
 import { Intent } from '@/lib/enums';
 import { defaultConfig } from '../config/default-config';
@@ -32,7 +33,8 @@ export const validateSearchParams = (
     if (
       key === QueryParams.Widget &&
       (!Object.values(IntentMapping).includes(value.toLowerCase()) ||
-        !CHAIN_WIDGET_MAP[chainId].includes(mapQueryParamToIntent(value)))
+        !CHAIN_WIDGET_MAP[chainId].includes(mapQueryParamToIntent(value)) ||
+        COMING_SOON_MAP[chainId].includes(mapQueryParamToIntent(value)))
     ) {
       searchParams.delete(key);
     }

--- a/src/modules/utils/validateSearchParams.ts
+++ b/src/modules/utils/validateSearchParams.ts
@@ -34,7 +34,7 @@ export const validateSearchParams = (
       key === QueryParams.Widget &&
       (!Object.values(IntentMapping).includes(value.toLowerCase()) ||
         !CHAIN_WIDGET_MAP[chainId].includes(mapQueryParamToIntent(value)) ||
-        COMING_SOON_MAP[chainId].includes(mapQueryParamToIntent(value)))
+        COMING_SOON_MAP[chainId]?.includes(mapQueryParamToIntent(value)))
     ) {
       searchParams.delete(key);
     }

--- a/src/modules/utils/validateSearchParams.ts
+++ b/src/modules/utils/validateSearchParams.ts
@@ -1,6 +1,12 @@
 import { RewardContract } from '@jetstreamgg/hooks';
 import { SUPPORTED_TOKEN_SYMBOLS } from '@jetstreamgg/widgets';
-import { QueryParams, IntentMapping, VALID_LINKED_ACTIONS } from '@/lib/constants';
+import {
+  QueryParams,
+  IntentMapping,
+  VALID_LINKED_ACTIONS,
+  CHAIN_WIDGET_MAP,
+  mapQueryParamToIntent
+} from '@/lib/constants';
 import { Intent } from '@/lib/enums';
 import { defaultConfig } from '../config/default-config';
 
@@ -8,7 +14,8 @@ export const validateSearchParams = (
   searchParams: URLSearchParams,
   rewardContracts: RewardContract[],
   widget: string,
-  setSelectedRewardContract: (rewardContract?: RewardContract) => void
+  setSelectedRewardContract: (rewardContract?: RewardContract) => void,
+  chainId: number
 ) => {
   searchParams.forEach((value, key) => {
     // removes any query param not found in QueryParams
@@ -22,7 +29,11 @@ export const validateSearchParams = (
     }
 
     // removes widget param is value is not valid
-    if (key === QueryParams.Widget && !Object.values(IntentMapping).includes(value.toLowerCase())) {
+    if (
+      key === QueryParams.Widget &&
+      (!Object.values(IntentMapping).includes(value.toLowerCase()) ||
+        !CHAIN_WIDGET_MAP[chainId].includes(mapQueryParamToIntent(value)))
+    ) {
       searchParams.delete(key);
     }
 


### PR DESCRIPTION
- Add network switcher to the header of the widgets that are available in multiple chains (Balances, savings, and trade)
- Redirect to the balances widget if a user switches network while on a widget that is not supported in the new network (e.g. Switching from Mainnet to Base while on the Seal widget)