### PR TITLE
Update design of the coming soon label in the widget navigation tabs

### DIFF
--- a/src/modules/app/components/WidgetNavigation.tsx
+++ b/src/modules/app/components/WidgetNavigation.tsx
@@ -128,20 +128,23 @@ export function WidgetNavigation({ widgetContent, intent, children }: WidgetNavi
                 variant="icons"
                 value={widgetIntent}
                 className={cn(
-                  'px-1 md:px-2',
+                  'px-1 text-textSecondary data-[state=active]:text-text md:px-2',
                   'before:opacity-0',
-                  'disabled:cursor-not-allowed disabled:opacity-50 disabled:before:opacity-0 disabled:hover:before:opacity-0',
+                  'disabled:cursor-not-allowed disabled:text-[rgba(198,194,255,0.4)] disabled:before:opacity-0 disabled:hover:before:opacity-0',
                   intent === widgetIntent && tabGlowClasses
                 )}
                 disabled={options?.disabled || false}
               >
-                {!isMobile && icon({ color: intent === widgetIntent ? 'white' : 'rgba(198, 194, 255, 0.8)' })}
-                <Text variant="small">
+                {!isMobile && icon({ color: 'inherit' })}
+                <Text variant="small" className="text-inherit">
                   <Trans>{label}</Trans>
                 </Text>
                 {comingSoon && (
-                  <Text variant="small" className="text-nowrap text-[9px]">
-                    <Trans>Coming soon</Trans>
+                  <Text
+                    variant="small"
+                    className="absolute left-1/2 top-0 rounded-full bg-primary px-1.5 py-0 text-textSecondary md:px-2 md:py-1"
+                  >
+                    <Trans>Soon</Trans>
                   </Text>
                 )}
               </TabsTrigger>


### PR DESCRIPTION
Desktop:
![image](https://github.com/user-attachments/assets/03a01ed4-37a7-407c-b1a8-91fc5b2096e7)

Mobile:
![image](https://github.com/user-attachments/assets/a790041b-65d1-4ef9-9547-d0137e169e1c)
