### PR TITLE
Don't allow USDC for MiCa builds in the Base Savings module

### DIFF
--- a/src/modules/config/restrictedTokenList.ts
+++ b/src/modules/config/restrictedTokenList.ts
@@ -83,7 +83,12 @@ export const restrictedTokenListMiCa = {
     { ...eth, address: ETH_ADDRESS },
     { ...weth, address: wethSepoliaAddress[sepolia.id] },
     { ...dai, address: mcdDaiSepoliaAddress[sepolia.id] }
-  ]
+  ],
+  [base.id]: [
+    { ...usds, address: usdsBaseAddress[base.id] },
+    { ...eth, address: ETH_ADDRESS }
+  ],
+  [tenderlyBase.id]: [{ ...usds, address: usdsBaseAddress[TENDERLY_BASE_CHAIN_ID] }]
 };
 
 export const restrictedTokenListTrade = {

--- a/src/modules/savings/components/SavingsBalanceDetails.tsx
+++ b/src/modules/savings/components/SavingsBalanceDetails.tsx
@@ -9,6 +9,7 @@ export function SavingsBalanceDetails() {
   const { address } = useAccount();
   const { data, isLoading, error } = useSavingsData();
   const isBase = isBaseChainId(chainId);
+  const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
   const { data: usdcBalance } = useTokenBalance({
     chainId,
     address,
@@ -60,7 +61,7 @@ export function SavingsBalanceDetails() {
     );
   };
 
-  return isBase ? (
+  return isBase && !isRestrictedMiCa ? (
     <div className="flex w-full flex-col gap-3">
       <div className="w-full">
         <SuppliedSavingsBalanceCard />

--- a/src/modules/savings/components/SavingsWidgetPane.tsx
+++ b/src/modules/savings/components/SavingsWidgetPane.tsx
@@ -5,7 +5,7 @@ import {
   SavingsAction,
   WidgetStateChangeParams
 } from '@jetstreamgg/widgets';
-import { useSavingsHistory } from '@jetstreamgg/hooks';
+import { TOKENS, useSavingsHistory } from '@jetstreamgg/hooks';
 import { isBaseChainId } from '@jetstreamgg/utils';
 import { REFRESH_DELAY } from '@/lib/constants';
 import { SharedProps } from '@/modules/app/types/Widgets';
@@ -24,6 +24,9 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
   const chainId = useChainId();
 
   const isBaseChain = isBaseChainId(chainId);
+  const isRestrictedMiCa = import.meta.env.VITE_RESTRICTED_BUILD_MICA === 'true';
+  const disallowedTokens =
+    isRestrictedMiCa && isBaseChain ? { supply: [TOKENS.usdc], withdraw: [TOKENS.usdc] } : undefined;
 
   const onSavingsWidgetStateChange = ({ hash, txStatus, widgetState }: WidgetStateChangeParams) => {
     // After a successful linked action sUPPLY, set the final step to "success"
@@ -65,6 +68,7 @@ export function SavingsWidgetPane(sharedProps: SharedProps) {
         amount: linkedActionConfig?.inputAmount,
         token: isBaseChain ? linkedActionConfig?.sourceToken : undefined
       }}
+      disallowedTokens={disallowedTokens}
     />
   );
 }


### PR DESCRIPTION
How to test:

On Base, run the following scripts:

- dev: it should allow you to deposit/withdraw both USDC and USDS in the Savings module
- dev:restricted it shouldn't show you the Savings module at all 
- dev:restricted-mica it should only allow you to deposit/withdraw USDS in the Savings module